### PR TITLE
Rocana-2406 TestKeepWorkingDir fails after 100 executions

### DIFF
--- a/check.go
+++ b/check.go
@@ -133,10 +133,11 @@ type tempDir struct {
 func (td *tempDir) newPath() string {
 	td.Lock()
 	defer td.Unlock()
+	randSrc := rand.NewSource(time.Now().UnixNano())
 	if td.path == "" {
 		var err error
 		for i := 0; i != 100; i++ {
-			path := fmt.Sprintf("%s/check-%d", os.TempDir(), rand.Int())
+			path := fmt.Sprintf("%s/check-%d", os.TempDir(), randSrc.Int63())
 			if err = os.Mkdir(path, 0700); err == nil {
 				td.path = path
 				break

--- a/run_test.go
+++ b/run_test.go
@@ -409,7 +409,7 @@ func (s *RunS) TestKeepWorkDir(c *C) {
 	output := String{}
 	runConf := RunConf{Output: &output, Verbose: true, KeepWorkDir: true}
 	result := Run(&WorkDirSuite{}, &runConf)
-
+	defer os.RemoveAll(result.WorkDir)
 	c.Assert(result.String(), Matches, ".*\nWORK=" + result.WorkDir)
 
 	stat, err := os.Stat(result.WorkDir)


### PR DESCRIPTION
Rather than using `ioutil.TempDir`, check has it's own code for "get a random directory" which retries 100 times (https://github.com/scalingdata/check/blob/master/check.go#L133-L152). However:

- `TestKeepWorkingDir` doesn't clean up after itself
- `rand.Int` isn't seeded, so it produces the same deterministic sequence of outputs on every execution (https://golang.org/pkg/math/rand/)

The end result is that `TestKeepWorkingDir` will walk through the sequence of 100 directory names, and then start panicking on the 101st test. This would also apply to anyone using the `KeepWorkDir` argument.